### PR TITLE
Fix edge calculations and add missing options to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ The scanner supports detecting partly visible aliens on the edges of
 the radar readings.
 
 In order to avoid too many false positives, it only tries to match
-partial readings if a certain thereshold of the alien pattern is
+partial readings if a certain threshold of the alien pattern is
 not beyond each of the edges.
 
-This thereshold is predefined at 0.5 (50%) and can be adjusted with
-the `--edge-thereshold` runtime option (or simply `-e`.
+This threshold is predefined at 0.5 (50%) and can be adjusted with
+the `--edge-threshold` runtime option (or simply `-e`.
 
 So you can run
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ bundle exec alien_scan.rb scan path/to/reading_file
 
 ### Alien patterns
 
-On launch, the script loads the following alien patterns for
+Use the `--patterns` option (or simply `-p`) to specify a space
+separated list of files containing alien patterns.
+
+By default, the script loads the following alien patterns for
 recognition:
 
 ``` bash
@@ -66,9 +69,18 @@ data/alien01.txt
 data/alien02.txt
 ```
 
-At the moment, the executable script doesn't provide options to load a
-different set of patterns, although the underlying classes support an
-arbitrary number of them,
+You could get the same result with
+
+``` bash
+bundle exec alien_scan.rb scan path/to/reading_file -p
+data/alien01.txt data/alien02.txt
+```
+
+or simply
+
+``` bash
+bundle exec alien_scan.rb scan path/to/reading_file -p data/alien*.txt
+```
 
 ### Fuzzy matching
 
@@ -93,11 +105,19 @@ The scanner supports detecting partly visible aliens on the edges of
 the radar readings.
 
 In order to avoid too many false positives, it only tries to match
-partial readings if at most 50% of the alien pattern is beyond each of
-the edges.
+partial readings if a certain thereshold of the alien pattern is
+not beyond each of the edges.
 
-This thereshold is configurable in the internal classes but not in the
-CLI script.
+This thereshold is predefined at 0.5 (50%) and can be adjusted with
+the `--edge-thereshold` runtime option (or simply `-e`.
+
+So you can run
+
+``` bash
+bundle exec alien_scan.rb scan data/radar01.txt -e 0.8
+```
+
+to only find aliens where at least 80% of the pattern is visible.
 
 # Running tests
 

--- a/lib/aliens/cli.rb
+++ b/lib/aliens/cli.rb
@@ -7,11 +7,14 @@ module Aliens
   class CLI < Thor
     desc "scan", "Scan a radar reading looking for Aliens"
     option :minimum_confidence_factor, type: :numeric, aliases: 'c', default: 0.85
+    option :edge_thereshold, type: :numeric, aliases: 'e', default: 0.5
+    option :patterns, type: :array, aliases: 'p', default: %w[data/alien01.txt data/alien02.txt]
 
     def scan(reading = 'data/radar01.txt')
       alien_patterns = load_aliens
       aliens_scanner = Aliens::Scanner.new(alien_patterns,
-                                           minimum_confidence_factor: options[:minimum_confidence_factor])
+                                           minimum_confidence_factor: options[:minimum_confidence_factor],
+                                           edge_thereshold: options[:edge_thereshold])
       radar_reading = parser.parse(File.read(reading))
 
       bandits = aliens_scanner.scan(radar_reading)
@@ -28,10 +31,9 @@ module Aliens
     end
 
     def load_aliens
-      alien_patterns = []
-      alien_patterns << parser.parse(File.read('data/alien01.txt'))
-      alien_patterns << parser.parse(File.read('data/alien02.txt'))
-      alien_patterns
+      options[:patterns].map do |pattern|
+        parser.parse(File.read(pattern))
+      end
     end
 
     def show_results(bandits)

--- a/lib/aliens/cli.rb
+++ b/lib/aliens/cli.rb
@@ -7,14 +7,14 @@ module Aliens
   class CLI < Thor
     desc "scan", "Scan a radar reading looking for Aliens"
     option :minimum_confidence_factor, type: :numeric, aliases: 'c', default: 0.85
-    option :edge_thereshold, type: :numeric, aliases: 'e', default: 0.5
+    option :edge_threshold, type: :numeric, aliases: 'e', default: 0.5
     option :patterns, type: :array, aliases: 'p', default: %w[data/alien01.txt data/alien02.txt]
 
     def scan(reading = 'data/radar01.txt')
       alien_patterns = load_aliens
       aliens_scanner = Aliens::Scanner.new(alien_patterns,
                                            minimum_confidence_factor: options[:minimum_confidence_factor],
-                                           edge_thereshold: options[:edge_thereshold])
+                                           edge_threshold: options[:edge_threshold])
       radar_reading = parser.parse(File.read(reading))
 
       bandits = aliens_scanner.scan(radar_reading)

--- a/lib/aliens/scanner.rb
+++ b/lib/aliens/scanner.rb
@@ -47,13 +47,17 @@ module Aliens
     end
 
     def x_scan_range(radar_reading, pattern)
-      thereshold = (pattern.x_size * edge_thereshold).to_i
-      -thereshold..(radar_reading.x_size - thereshold)
+      thereshold = (pattern.x_size * edge_thereshold).ceil
+      start_x = -pattern.x_size + thereshold
+      end_x = radar_reading.x_size - thereshold
+      start_x..end_x
     end
 
     def y_scan_range(radar_reading, pattern)
-      thereshold = (pattern.y_size * edge_thereshold).to_i
-      -thereshold..(radar_reading.y_size - thereshold)
+      thereshold = (pattern.y_size * edge_thereshold).ceil
+      start_y = -pattern.y_size + thereshold
+      end_y = radar_reading.y_size - thereshold
+      start_y..end_y
     end
 
     def match_pattern(radar_reading, pattern, x, y)

--- a/lib/aliens/scanner.rb
+++ b/lib/aliens/scanner.rb
@@ -5,7 +5,7 @@ module Aliens
   class Scanner
     attr_reader :alien_patterns
     attr_reader :minimum_confidence_factor
-    attr_reader :edge_thereshold
+    attr_reader :edge_threshold
     attr_reader :matcher
     attr_reader :clipper
     attr_reader :results_class
@@ -14,13 +14,13 @@ module Aliens
     # rubocop:disable Metrics/ParameterLists
     def initialize(alien_patterns,
                    minimum_confidence_factor: 0.85,
-                   edge_thereshold: 0.5,
+                   edge_threshold: 0.5,
                    clipper_class: Clipper, clipper: clipper_class.new,
                    matcher_class: Matcher, matcher: matcher_class.new,
                    results_class: Result)
       @alien_patterns = alien_patterns
       @minimum_confidence_factor = minimum_confidence_factor
-      @edge_thereshold = edge_thereshold
+      @edge_threshold = edge_threshold
       @clipper = clipper
       @matcher = matcher
       @results_class = results_class
@@ -47,16 +47,16 @@ module Aliens
     end
 
     def x_scan_range(radar_reading, pattern)
-      thereshold = (pattern.x_size * edge_thereshold).ceil
-      start_x = -pattern.x_size + thereshold
-      end_x = radar_reading.x_size - thereshold
+      threshold = (pattern.x_size * edge_threshold).ceil
+      start_x = -pattern.x_size + threshold
+      end_x = radar_reading.x_size - threshold
       start_x..end_x
     end
 
     def y_scan_range(radar_reading, pattern)
-      thereshold = (pattern.y_size * edge_thereshold).ceil
-      start_y = -pattern.y_size + thereshold
-      end_y = radar_reading.y_size - thereshold
+      threshold = (pattern.y_size * edge_threshold).ceil
+      start_y = -pattern.y_size + threshold
+      end_y = radar_reading.y_size - threshold
       start_y..end_y
     end
 

--- a/spec/matcher_spec.rb
+++ b/spec/matcher_spec.rb
@@ -124,7 +124,7 @@ describe Aliens::Matcher do
   end
 
   describe "fuzzy matches" do
-    let(:thereshold) { 0.85 }
+    let(:threshold) { 0.85 }
 
     it "orders aliens by closeness" do
       reading1_score = subject.match(alien1, reading1)
@@ -136,18 +136,18 @@ describe Aliens::Matcher do
       expect(reading3_score).to be >= reading4_score
     end
 
-    it "puts reasonable matches above thereshold" do
+    it "puts reasonable matches above threshold" do
       reading1_score = subject.match(alien1, reading1)
       reading2_score = subject.match(alien1, reading2)
-      expect(reading1_score).to be > thereshold
-      expect(reading2_score).to be > thereshold
+      expect(reading1_score).to be > threshold
+      expect(reading2_score).to be > threshold
     end
 
-    it "puts hard matches below thereshold" do
+    it "puts hard matches below threshold" do
       reading3_score = subject.match(alien1, reading3)
       reading4_score = subject.match(alien1, reading4)
-      expect(reading3_score).to be < thereshold
-      expect(reading4_score).to be < thereshold
+      expect(reading3_score).to be < threshold
+      expect(reading4_score).to be < threshold
     end
   end
 end

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -63,6 +63,293 @@ describe Aliens::Scanner do
     end
   end
 
+  describe "edge cases" do
+    let(:alien) do
+      pattern = <<~TEXT
+        ooooo
+        o---o
+        o---o
+        o---o
+        ooooo
+      TEXT
+      parser.parse(pattern)
+    end
+
+    let(:reading_no_partials) do
+      pattern = <<~TEXT
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+        -------ooooo-------
+        -------o---o-------
+        -------o---o-------
+        -------o---o-------
+        -------ooooo-------
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+      TEXT
+      parser.parse(pattern)
+    end
+
+    let(:reading_partials20) do
+      pattern = <<~TEXT
+        o--------ooooo----o
+        -------------------
+        -------------------
+        -------------------
+        ------------------o
+        ------------------o
+        o------ooooo------o
+        o------o---o------o
+        o------o---o------o
+        o------o---o-------
+        o------ooooo-------
+        -------------------
+        -------------------
+        -------------------
+        -------------------
+        o-----------------o
+      TEXT
+      parser.parse(pattern)
+    end
+
+    let(:reading_partials40) do
+      pattern = <<~TEXT
+        -o-------o---o---o-
+        oo-------ooooo---oo
+        -------------------
+        -------------------
+        -----------------oo
+        -----------------o-
+        oo-----ooooo-----o-
+        -o-----o---o-----o-
+        -o-----o---o-----oo
+        -o-----o---o-------
+        oo-----ooooo-------
+        -------------------
+        -------------------
+        -------------------
+        oo---------------oo
+        -o---------------o-
+      TEXT
+      parser.parse(pattern)
+    end
+
+    let(:reading_partials60) do
+      pattern = <<~TEXT
+        --o------o---o--o--
+        --o------o---o--o--
+        ooo------ooooo--ooo
+        -------------------
+        ----------------ooo
+        ----------------o--
+        ooo----ooooo----o--
+        --o----o---o----o--
+        --o----o---o----ooo
+        --o----o---o-------
+        ooo----ooooo-------
+        -------------------
+        -------------------
+        ooo-------------ooo
+        --o-------------o--
+        --o-------------o--
+      TEXT
+      parser.parse(pattern)
+    end
+
+    let(:reading_partials80) do
+      pattern = <<~TEXT
+        ---o-----o---o-o---
+        ---o-----o---o-o---
+        ---o-----o---o-o---
+        oooo-----ooooo-oooo
+        ---------------oooo
+        ---------------o---
+        oooo---ooooo---o---
+        ---o---o---o---o---
+        ---o---o---o---oooo
+        ---o---o---o-------
+        oooo---ooooo-------
+        -------------------
+        oooo-----------oooo
+        ---o-----------o---
+        ---o-----------o---
+        ---o-----------o---
+      TEXT
+      parser.parse(pattern)
+    end
+
+    context "with default edge thereshold" do
+      let(:scanner) { Aliens::Scanner.new([alien], minimum_confidence_factor: 1) }
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases well below thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(1)
+      end
+
+      it "works with edge cases just below thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(1)
+      end
+
+      it "works with edge cases just above thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(8)
+      end
+
+      it "works with edge cases well above thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(8)
+      end
+    end
+
+    context "with 20% edge thereshold" do
+      let(:scanner) do
+        Aliens::Scanner.new([alien],
+                            edge_thereshold: 0.2,
+                            minimum_confidence_factor: 1)
+      end
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases exactly on thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(8)
+      end
+
+      it "works with edge cases just above thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(8)
+      end
+
+      it "works with edge cases well above thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(8)
+      end
+
+      it "works with edge cases far above thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(8)
+      end
+    end
+
+    context "with 40% edge thereshold" do
+      let(:scanner) do
+        Aliens::Scanner.new([alien],
+                            edge_thereshold: 0.4,
+                            minimum_confidence_factor: 1)
+      end
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases below thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(1)
+      end
+
+      it "works with edge cases exactly on thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(8)
+      end
+
+      it "works with edge cases just above thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(8)
+      end
+
+      it "works with edge cases well above thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(8)
+      end
+    end
+
+    context "with 60% edge thereshold" do
+      let(:scanner) do
+        Aliens::Scanner.new([alien],
+                            edge_thereshold: 0.6,
+                            minimum_confidence_factor: 1)
+      end
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases far below thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(1)
+      end
+
+      it "works with edge cases just below thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(1)
+      end
+
+      it "works with edge cases exactly on thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(8)
+      end
+
+      it "works with edge cases just above thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(8)
+      end
+    end
+
+    context "with 80% edge thereshold" do
+      let(:scanner) do
+        Aliens::Scanner.new([alien],
+                            edge_thereshold: 0.8,
+                            minimum_confidence_factor: 1)
+      end
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases far below thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(1)
+      end
+
+      it "works with edge cases well below thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(1)
+      end
+
+      it "works with edge cases just below thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(1)
+      end
+
+      it "works with edge cases exactly on thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(8)
+      end
+    end
+
+    context "with no edge thereshold" do
+      let(:scanner) do
+        Aliens::Scanner.new([alien],
+                            edge_thereshold: 1.0,
+                            minimum_confidence_factor: 1)
+      end
+
+      it "works with no edge cases" do
+        expect(scanner.scan(reading_no_partials).size).to eq(1)
+      end
+
+      it "works with edge cases below thereshold" do
+        expect(scanner.scan(reading_partials20).size).to eq(1)
+      end
+
+      it "works with edge cases below thereshold" do
+        expect(scanner.scan(reading_partials40).size).to eq(1)
+      end
+
+      it "works with edge cases below thereshold" do
+        expect(scanner.scan(reading_partials60).size).to eq(1)
+      end
+
+      it "works with edge cases below thereshold" do
+        expect(scanner.scan(reading_partials80).size).to eq(1)
+      end
+    end
+  end
+
   describe "collecting positives" do
     let(:dumb_matcher) { Aliens::Matcher.new }
     let(:scanner) { Aliens::Scanner.new([alien], matcher: dumb_matcher) }

--- a/spec/scanner_spec.rb
+++ b/spec/scanner_spec.rb
@@ -185,34 +185,34 @@ describe Aliens::Scanner do
       parser.parse(pattern)
     end
 
-    context "with default edge thereshold" do
+    context "with default edge threshold" do
       let(:scanner) { Aliens::Scanner.new([alien], minimum_confidence_factor: 1) }
 
       it "works with no edge cases" do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases well below thereshold" do
+      it "works with edge cases well below threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(1)
       end
 
-      it "works with edge cases just below thereshold" do
+      it "works with edge cases just below threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(1)
       end
 
-      it "works with edge cases just above thereshold" do
+      it "works with edge cases just above threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(8)
       end
 
-      it "works with edge cases well above thereshold" do
+      it "works with edge cases well above threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(8)
       end
     end
 
-    context "with 20% edge thereshold" do
+    context "with 20% edge threshold" do
       let(:scanner) do
         Aliens::Scanner.new([alien],
-                            edge_thereshold: 0.2,
+                            edge_threshold: 0.2,
                             minimum_confidence_factor: 1)
       end
 
@@ -220,27 +220,27 @@ describe Aliens::Scanner do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases exactly on thereshold" do
+      it "works with edge cases exactly on threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(8)
       end
 
-      it "works with edge cases just above thereshold" do
+      it "works with edge cases just above threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(8)
       end
 
-      it "works with edge cases well above thereshold" do
+      it "works with edge cases well above threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(8)
       end
 
-      it "works with edge cases far above thereshold" do
+      it "works with edge cases far above threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(8)
       end
     end
 
-    context "with 40% edge thereshold" do
+    context "with 40% edge threshold" do
       let(:scanner) do
         Aliens::Scanner.new([alien],
-                            edge_thereshold: 0.4,
+                            edge_threshold: 0.4,
                             minimum_confidence_factor: 1)
       end
 
@@ -248,27 +248,27 @@ describe Aliens::Scanner do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases below thereshold" do
+      it "works with edge cases below threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(1)
       end
 
-      it "works with edge cases exactly on thereshold" do
+      it "works with edge cases exactly on threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(8)
       end
 
-      it "works with edge cases just above thereshold" do
+      it "works with edge cases just above threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(8)
       end
 
-      it "works with edge cases well above thereshold" do
+      it "works with edge cases well above threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(8)
       end
     end
 
-    context "with 60% edge thereshold" do
+    context "with 60% edge threshold" do
       let(:scanner) do
         Aliens::Scanner.new([alien],
-                            edge_thereshold: 0.6,
+                            edge_threshold: 0.6,
                             minimum_confidence_factor: 1)
       end
 
@@ -276,27 +276,27 @@ describe Aliens::Scanner do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases far below thereshold" do
+      it "works with edge cases far below threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(1)
       end
 
-      it "works with edge cases just below thereshold" do
+      it "works with edge cases just below threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(1)
       end
 
-      it "works with edge cases exactly on thereshold" do
+      it "works with edge cases exactly on threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(8)
       end
 
-      it "works with edge cases just above thereshold" do
+      it "works with edge cases just above threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(8)
       end
     end
 
-    context "with 80% edge thereshold" do
+    context "with 80% edge threshold" do
       let(:scanner) do
         Aliens::Scanner.new([alien],
-                            edge_thereshold: 0.8,
+                            edge_threshold: 0.8,
                             minimum_confidence_factor: 1)
       end
 
@@ -304,27 +304,27 @@ describe Aliens::Scanner do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases far below thereshold" do
+      it "works with edge cases far below threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(1)
       end
 
-      it "works with edge cases well below thereshold" do
+      it "works with edge cases well below threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(1)
       end
 
-      it "works with edge cases just below thereshold" do
+      it "works with edge cases just below threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(1)
       end
 
-      it "works with edge cases exactly on thereshold" do
+      it "works with edge cases exactly on threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(8)
       end
     end
 
-    context "with no edge thereshold" do
+    context "with no edge threshold" do
       let(:scanner) do
         Aliens::Scanner.new([alien],
-                            edge_thereshold: 1.0,
+                            edge_threshold: 1.0,
                             minimum_confidence_factor: 1)
       end
 
@@ -332,19 +332,19 @@ describe Aliens::Scanner do
         expect(scanner.scan(reading_no_partials).size).to eq(1)
       end
 
-      it "works with edge cases below thereshold" do
+      it "works with edge cases below threshold" do
         expect(scanner.scan(reading_partials20).size).to eq(1)
       end
 
-      it "works with edge cases below thereshold" do
+      it "works with edge cases below threshold" do
         expect(scanner.scan(reading_partials40).size).to eq(1)
       end
 
-      it "works with edge cases below thereshold" do
+      it "works with edge cases below threshold" do
         expect(scanner.scan(reading_partials60).size).to eq(1)
       end
 
-      it "works with edge cases below thereshold" do
+      it "works with edge cases below threshold" do
         expect(scanner.scan(reading_partials80).size).to eq(1)
       end
     end


### PR DESCRIPTION
There was an error in the application of the `edge_threshold` option of the scanner.

This PR fixes that error and adds specs to test for these problems.

In addition, it adds the `--edge_threshold` command line option to set the value on launch.

Last, it also adds the `--patterns` command line option to select alien pattern files on launch.